### PR TITLE
Drop unpinned npm@latest from the general-coding image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sandbox-general` image build no longer breaks when npm ships a new major.** The general-coding Dockerfile ran an unpinned `npm install -g npm@latest` after installing Node 20; npm 12 (2026-07) requires Node >= 22, so every fresh build failed with `EBADENGINE`. The image now keeps the npm bundled with the pinned Node major. Found by the post-merge end-to-end deploy validation.
 - **The `claude-code-bedrock` default template was silently dropped on every install.** A missing `---` document separator merged it into the next YAML document, so only 5 of 6 ClusterSandboxTemplates ever reached the API server.
 - **Security audit findings:** the Router's CORS middleware reflected `*` while accepting credentialed headers — replaced with a strict origin allowlist (`cors.allowedOrigins`, disallowed preflights get 403, `Vary: Origin` set); `/admin/sandboxes` and `/admin/sharing` were reachable without admin — now behind `requireAdmin`; API-key hash comparison is constant-time; Router shutdown drains on an independent 30 s budget via `signal.NotifyContext`; dev-auth and webhook `failurePolicy != Fail` now log unmissable warnings.
 - Helm chart bundles CRDs in `crds/` so a fresh `helm install` registers CRD kinds before the default-template CRs render; rename-drift leftovers (LICENSE copyright, CODEOWNERS, nginx.conf upstream, e2e-test names) corrected; `make verify-codegen` no longer crashes on a dead controller-gen flag and scopes its diff to actual generated files.

--- a/images/general-coding/Dockerfile
+++ b/images/general-coding/Dockerfile
@@ -75,9 +75,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js 20 LTS (nodesource setup handles both architectures).
+# Deliberately NO `npm install -g npm@latest`: the image ships the npm that
+# the pinned Node major bundles. An unpinned "latest" broke this build on
+# 2026-07-16 when npm 12 released requiring Node >= 22 (EBADENGINE) — the
+# same class of drift digest-pinning exists to prevent.
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
 
 # Python 3.11


### PR DESCRIPTION
Root cause of the failed post-merge deploy validation: npm 12 requires Node >= 22, so the image's 'npm install -g npm@latest' on pinned Node 20 dies with EBADENGINE. Keep the npm bundled with the pinned Node major (10.8.2 today). Verified by re-running the full CodeBuild image build on the validation cluster (see PR comment to follow with the green build).